### PR TITLE
Updated line #13 to avoid <<NAN>> value

### DIFF
--- a/CollapsibleView/index.js
+++ b/CollapsibleView/index.js
@@ -10,7 +10,7 @@ import PropTypes from "prop-types";
 
 export default class CollapsibleView extends Component {
   animationObject = {
-    height: new Animated.Value(),
+    height: new Animated.Value(0),
     collapsed: false,
     contentHeight: 0
   };


### PR DESCRIPTION
I'm getting this error 

**Invariant Violation: Invariant Violation: [1055,"RCTView",381,{"onLayout":true,"height":"<<NaN>>"}] is not usable as a native method argument**

